### PR TITLE
Linux: build against libstdc++ and create nested objdir

### DIFF
--- a/.mk.defs
+++ b/.mk.defs
@@ -5,7 +5,7 @@ CC = clang++
 CPP = $(CC) -E
 AR = ar
 
-CFLAGS = -fPIC -stdlib=libc++ -std=c++11 -Wall -I$(PLUGIN_DEF_DIR)
+CFLAGS = -fPIC  -std=c++11 -Wall -I$(PLUGIN_DEF_DIR)
 
 ifndef DBG
 CFLAGS += -O2

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BUILD_DIR = .
 SUBDIRS = wrapper
 
 ifeq ($(OS_TYPE), Linux)
-LDFLAGS = -shared '-Wl,-rpath,$$ORIGIN' -Wl,-z,origin -lpthread -stdlib=libc++ -lavcodec -lavutil
+LDFLAGS = -shared '-Wl,-rpath,$$ORIGIN' -Wl,-z,origin -lpthread  -lavcodec -lavutil
 else
 LDFLAGS = -dynamiclib
 endif
@@ -19,16 +19,22 @@ BINDIR = $(BUILD_DIR)/bin
 .PHONY: all
 
 HEADERS = plugin.h audio_encoder.h
-SRCS = plugin.cpp audio_encoder.cpp
+SRCS = plugin.cpp audio_encoder.cpp wrapper/host_api.cpp
 OBJS = $(SRCS:%.cpp=$(OBJDIR)/%.o)
+
+CFLAGS += -I$(BASEDIR)/wrapper -I/usr/include/c++/14 -stdlib=libstdc++ -I/usr/include/c++/x86_64-redhat-linux/14
 
 all: prereq make-subdirs $(HEADERS) $(SRCS) $(OBJS) $(TARGET)
 
 prereq:
 	mkdir -p $(OBJDIR)
 	mkdir -p $(BINDIR)
+	mkdir -p $(OBJDIR)/wrapper  # Ensure wrapper directory exists
 
 $(OBJDIR)/%.o: %.cpp
+	$(CC) -c -o $@ $< $(CFLAGS)
+
+$(OBJDIR)/wrapper/%.o: wrapper/%.cpp
 	$(CC) -c -o $@ $< $(CFLAGS)
 
 $(TARGET):
@@ -50,3 +56,4 @@ clean-subdirs:
 	echo "Making clean in $$subdir"; \
 	(cd $$subdir; make clean; cd ..) \
 	done
+


### PR DESCRIPTION
- Drop -stdlib=libc++ on Linux so clang uses libstdc++ (fixes <map> and -lc++).
- Ensure build/wrapper/ exists before compiling nested sources.
- Avoid hardcoded distro include paths.
